### PR TITLE
Fixing a typo.. should be 0x03 as the ID...

### DIFF
--- a/protocol/PONG_DataPacket.php
+++ b/protocol/PONG_DataPacket.php
@@ -24,7 +24,7 @@ namespace raklib\protocol;
 #include <rules/RakLibPacket.h>
 
 class PONG_DataPacket extends Packet{
-    public static $ID = 0x00;
+    public static $ID = 0x03;
 
     public $pingID;
 


### PR DESCRIPTION
According to http://wiki.vg/Pocket_Minecraft_Protocol#Pong_Packet_.280x03.29, it should be 0x03...